### PR TITLE
Fix search filter

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,7 @@
+=== 2.0.7 / 18.07.2016
+
+* Fixed search filter
+
 === 2.0.6 / 13.07.2016
 
 * Fixed running test/suite.rb by suppressing test_invoicer, which runs fine if run standalone

--- a/lib/bbmb/version.rb
+++ b/lib/bbmb/version.rb
@@ -2,5 +2,5 @@
 # Bbmb -- bbmb.ch -- 17.12.2019 -- zdavatz@ywesee.com
 
 module BBMB
-  VERSION = '2.0.6'
+  VERSION = '2.0.7'
 end


### PR DESCRIPTION
@zdavatz (cc: @ngiger)

I've already updated sbsm in apache config on production to 1.2.8 (installed for Ruby 2.3.1).
It works any problem.

And then, this change avoids errors by invalid sequence and skip empty string.
