### PR TITLE
Add `to_product` utility method

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,7 @@
+=== 2.1.0 / 19.08.2016
+
+* Add ProductInfo#to_product utility method
+
 === 2.0.9 / 20.07.2016
 
 * Add EAN-Code as search target

--- a/lib/bbmb/version.rb
+++ b/lib/bbmb/version.rb
@@ -1,3 +1,3 @@
 module BBMB
-  VERSION = '2.0.9'
+  VERSION = '2.1.0'
 end

--- a/test/model/test_product.rb
+++ b/test/model/test_product.rb
@@ -79,13 +79,29 @@ class TestProduct < Minitest::Test
     @product.l6_price = 16.50
     assert_equal(16.50, @product.price(6))
   end
-  def test_info
+
+  def test_to_info
     info = @product.to_info
     assert_instance_of(ProductInfo, info)
     assert_equal('article_number', info.article_number)
-    info1 = info.to_info
-    assert_equal(info, info1)
+    assert_equal(info, info.to_info)
   end
+
+  def test_to_product
+    product = @product.to_info.to_product
+    assert_instance_of(Product, product)
+    assert_equal('article_number', product.article_number)
+    assert_equal(product, product.to_product)
+    %w{
+      backorder_date catalogue1 catalogue2 catalogue3
+      description ean13 expiry_date partner_index pcode status
+    }.map do |attr|
+      assert_equal(@product.send(attr), product.send(attr))
+    end
+    assert_equal(@product.promotion, product.promotion)
+    assert_equal(@product.sale, product.sale)
+  end
+
   def test_price_levels__no_promo
     @product.l1_qty = 1
     @product.l1_price = 10


### PR DESCRIPTION
I've added `ProductInfo#to_product` method.
By this change, we can convert `product` <==> `product_info`.

@zdavatz 
Please merge @ngiger 's change before this pull request.
He has fixed test suite :)
https://github.com/ngiger/bbmb
